### PR TITLE
fix: adding exclude paths to tsconfig.decl.json

### DIFF
--- a/tsconfig.decl.json
+++ b/tsconfig.decl.json
@@ -4,5 +4,10 @@
     "emitDeclarationOnly": true,
     "declarationDir": "types",
     "rootDir": "src"
-  }
+  },
+  "exclude": [
+    "tests/**",
+    "dist/**",
+    "node_modules/**"
+  ]
 }


### PR DESCRIPTION
Building of declarations trigger error TS6059 that *.test.ts files is not into the rootDir, and that trigger failure of the build